### PR TITLE
CI: Add workflow to build snap and run upstream tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,14 +64,14 @@ jobs:
           ref: ${{ steps.get_tag.outputs.tag }}
 
       - name: Run lite-test
-        run: STRESS_NG=/snap/bin/stress-ng debian/tests/lite-test
+        run: sudo STRESS_NG=/snap/bin/stress-ng debian/tests/lite-test
 
       - name: Run fast-test-all
-        run: STRESS_NG=/snap/bin/stress-ng debian/tests/fast-test-all
+        run: sudo STRESS_NG=/snap/bin/stress-ng debian/tests/fast-test-all
 
       - name: Run verify-test-all
-        run: stress-ng --seq 0 -t 15 --pathological --times --tz --metrics --klog-check --progress --cache-enable-all -x smi || true
+        run: sudo stress-ng --seq 0 -t 15 --pathological --times --tz --metrics --klog-check --progress --cache-enable-all -x smi || true
 
       - name: Run slow-test-all
-        run: stress-ng --seq 0 -t 5 --pathological --times --tz --metrics --verify --progress --cache-enable-all -x smi || true
+        run: sudo stress-ng --seq 0 -t 5 --pathological --times --tz --metrics --verify --progress --cache-enable-all -x smi || true
 


### PR DESCRIPTION
- Build on Monday morning 01:00 UTC, since the slow tests take near 2 hours to run.
- Automatically fetches the latest tag for stress-ng source code.
- Add patch to run tests from snap app instead of local binary