### PR TITLE
add: Install hook preventing installation on Non-UC systems

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,8 +3,8 @@
 # Verify if SNAP_SAVE_DATA is unset, indicating the system is not Ubuntu Core
 # see: https://snapcraft.io/docs/environment-variables#heading--snap-save-data
 if [ -z "${SNAP_SAVE_DATA}" ]; then
-  echo -e "Error: Non-Ubuntu Core system detected."
-  echo -e "\tThis snap is designed to be installed only on Ubuntu Core systems (https://ubuntu.com/core)."
-  echo -e "\tIf you are using a non-Ubuntu Core system, please install stress-ng using your distribution's default package manager."
+  echo -e "Error: detected non-Ubuntu Core system."
+  echo -e "This snap is meant for Ubuntu Core (https://ubuntu.com/core) only."
+  echo -e "\nRefer to the project documentation for other installation methods: https://github.com/ColinIanKing/stress-ng/blob/master/README.md"
   exit 1
 fi


### PR DESCRIPTION
In case of attempt to install in a non-Ubuntu Core system, gives the error:

```console
$ sudo snap install ./stress-ng-dev_0.17.06+d99f50a_amd64.snap --devmode
error: cannot perform the following tasks:
- Run install hook of "stress-ng-dev" snap if present (run hook "install":
-----
Error: Non-Ubuntu Core system detected.
	This snap is designed to be installed only on Ubuntu Core systems (https://ubuntu.com/core).
	If you are using a non-Ubuntu Core system, please install stress-ng using your distribution's default package manager.
-----)
```